### PR TITLE
Some more small fixes

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -64,6 +64,7 @@ jobs:
             token: ${{ secrets.CODECOV_TOKEN }}
             name: codecov-umbrella
             fail_ci_if_error: true
+            verbose: true
           attempt_limit: 5
           attempt_delay: 30000
 
@@ -82,5 +83,6 @@ jobs:
 #            token: ${{ secrets.CODECOV_TOKEN }}
 #            name: codecov-umbrella
 #            fail_ci_if_error: true
+#            verbose: true
 #          attempt_limit: 5
 #          attempt_delay: 30000

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -57,6 +57,7 @@ jobs:
             token: ${{ secrets.CODECOV_TOKEN }}
             name: codecov-umbrella
             fail_ci_if_error: true
+            verbose: true
           attempt_limit: 5
           attempt_delay: 30000
       - name: Setup yarn
@@ -73,5 +74,6 @@ jobs:
             token: ${{ secrets.CODECOV_TOKEN }}
             name: codecov-umbrella
             fail_ci_if_error: true
+            verbose: true
           attempt_limit: 5
           attempt_delay: 30000

--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ next-env.d.ts
 /metrics/
 /logs/
 /.ruff_cache/
+/.swc/

--- a/florist/api/routes/server/job.py
+++ b/florist/api/routes/server/job.py
@@ -11,7 +11,7 @@ router = APIRouter()
 
 
 @router.post(
-    path="/",
+    path="",
     response_description="Create a new job",
     status_code=status.HTTP_201_CREATED,
     response_model=Job,


### PR DESCRIPTION
# PR Type
Fix

# Short Description

Clickup Ticket(s): NA

Adding some more small fixes here in order to avoid polluting my next PR:
- Adding `verbose: true` on codecov to help debug failure runs
- Adding the `.swc` folder to gitignore
- Removing the trailing slash on `/api/server/job` route which was causing problems with Next.js' redirect

# Tests Added
NA
