### PR TITLE
Adding use-cases to the documentation

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -2,7 +2,7 @@
 hide-toc: true
 ---
 
-# FLorist
+# <img src="https://github.com/VectorInstitute/FLorist/assets/11467898/5c7bcdef-311f-4a88-ae72-ed16f76b7c03" alt="FLorist logo" width="40"/> FLorist
 
 ```{toctree}
 :hidden:
@@ -29,3 +29,41 @@ training artifacts (e.g. model files). For a visual representation of the system
 the diagram below.
 
 ![system_diagram.png](system_diagram.png)
+
+## Use Cases
+
+### 1. Facilitate the orchestration of FL4Health training process
+
+**Scenario**: The process of training an FL4Health model is manual and cumbersome,
+requiring a lot of technical and programming knowledge.
+
+**Steps**:
+- Provide an easy-to-use UI to set up the parameters of a training job
+- Display the progress and preliminary metrics while training is happening
+- Display the results if successful, or centralized error messages
+and logs if not
+- Make the training artifacts (e.g. models) easily accessible in a centralized place
+
+### 2. Facilitate the use of state-of-the-art FL implementations
+
+**Scenario**: State-of-the-art algorithms implemented in FL4Health are not
+easy to be adopted because of the relatively high learning curve.
+
+**Steps**:
+- By providing an easy-to-use UI, the learning curve to adopt FL4Health is reduced
+- Providing a centralized place to see the progress, access the logs and the
+training artifacts also lowers the barrier of adoption
+- Having a system where training jobs can be easily restarted with different
+parameters facilitates experimentation
+
+### 3. Provide a useful tool to the open source community
+
+**Scenario**: There is a scarcity of tools for orchestrating and managing
+FL training jobs in the OSS community.
+
+**Steps**:
+- Develop a high-quality, easy-to-use and extensible tool for managing FL
+training jobs in FL4Health and later Flower in general
+- Use the latest and greatest front-end and back-end technologies and code
+practices
+- Provide a robust and visually enticing user interface


### PR DESCRIPTION
# PR Type
Documentation

# Short Description

Clickup Ticket(s): NA

Adding use-cases of FLorist in order to have it displayed on Vector's website (https://vectorinstitute.ai/ai-trust-and-safety/resources-projects-tools-frameworks-and-best-practices/?trk=feed_main-feed-card_feed-article-content).

I have added 3 use-cases here that I got from the project proposal. Please let me know if I should add, modify or remove anything. Thanks :)

# Tests Added
NA
