### PR TITLE
Stop a training job

### DIFF
--- a/florist/api/client.py
+++ b/florist/api/client.py
@@ -109,12 +109,14 @@ def kill(pid: str) -> JSONResponse:
     Kills the client process with given PID.
 
     :param pid: (str) the PID of the client to be killed.
-
     :return: (JSONResponse) If successful, returns 200. If not successful, returns the appropriate
         error code with a JSON with the format below:
             {"error": <error message>}
     """
     try:
+        if not pid:
+            return JSONResponse({"error": f"PID is not valid: {pid}"}, status_code=400)
+
         os.kill(int(pid), signal.SIGTERM)
         LOGGER.info(f"Killed process with PID {pid}")
         return JSONResponse(content={"status": "success"})

--- a/florist/api/client.py
+++ b/florist/api/client.py
@@ -41,9 +41,9 @@ def start(server_address: str, client: str, data_path: str, redis_host: str, red
     :param data_path: (str) the path where the training data is located.
     :param redis_host: (str) the host name for the Redis instance for metrics reporting.
     :param redis_port: (str) the port for the Redis instance for metrics reporting.
-    :return: (JSONResponse) If successful, returns 200 with a JSON containing the UUID for the client in the
-        format below, which can be used to pull metrics from Redis.
-            {"uuid": <client uuid>}
+    :return: (JSONResponse) If successful, returns 200 with a JSON containing the UUID and the PID for the client
+        in the format below, which can be used to pull metrics from Redis.
+            {"uuid": <client uuid>, "pid": <client pid>}
         If not successful, returns the appropriate error code with a JSON with the format below:
             {"error": <error message>}
     """
@@ -66,9 +66,9 @@ def start(server_address: str, client: str, data_path: str, redis_host: str, red
         )
 
         log_file_name = str(get_client_log_file_path(client_uuid))
-        launch_client(client_obj, server_address, log_file_name)
+        client_process = launch_client(client_obj, server_address, log_file_name)
 
-        return JSONResponse({"uuid": client_uuid})
+        return JSONResponse({"uuid": client_uuid, "pid": str(client_process.pid)})
 
     except Exception as ex:
         return JSONResponse({"error": str(ex)}, status_code=500)

--- a/florist/api/client.py
+++ b/florist/api/client.py
@@ -134,12 +134,12 @@ def stop(pid: str) -> JSONResponse:
             {"error": <error message>}
     """
     try:
-        if not pid:
-            return JSONResponse({"error": f"PID is not valid: {pid}"}, status_code=400)
-
+        assert pid, "PID is empty or None."
         os.kill(int(pid), signal.SIGTERM)
         LOGGER.info(f"Killed process with PID {pid}")
         return JSONResponse(content={"status": "success"})
+    except AssertionError as err:
+        return JSONResponse(content={"error": str(err)}, status_code=400)
     except Exception as ex:
         LOGGER.exception(ex)
         return JSONResponse({"error": str(ex)}, status_code=500)

--- a/florist/api/client.py
+++ b/florist/api/client.py
@@ -44,7 +44,7 @@ def start(server_address: str, client: str, data_path: str, redis_host: str, red
     :param redis_host: (str) the host name for the Redis instance for metrics reporting.
     :param redis_port: (str) the port for the Redis instance for metrics reporting.
     :return: (JSONResponse) If successful, returns 200 with a JSON containing the UUID, the PID and the log
-        file patth for the client in the format below:
+        file path for the client in the format below:
             {
                 "uuid": (str) The client's uuid, which can be used to pull metrics from Redis,
                 "log_file_path": (str) The local path of the log file for this client,

--- a/florist/api/client.py
+++ b/florist/api/client.py
@@ -103,8 +103,8 @@ def check_status(client_uuid: str, redis_host: str, redis_port: str) -> JSONResp
 
 
 # TODO verify the safety of this call
-@app.get("/api/client/kill/{pid}")
-def kill(pid: str) -> JSONResponse:
+@app.get("/api/client/stop/{pid}")
+def stop(pid: str) -> JSONResponse:
     """
     Kills the client process with given PID.
 

--- a/florist/api/client.py
+++ b/florist/api/client.py
@@ -1,6 +1,8 @@
 """FLorist client FastAPI endpoints."""
 
 import logging
+import os
+import signal
 import uuid
 from pathlib import Path
 
@@ -95,6 +97,27 @@ def check_status(client_uuid: str, redis_host: str, redis_port: str) -> JSONResp
 
         return JSONResponse({"error": f"Client {client_uuid} Not Found"}, status_code=404)
 
+    except Exception as ex:
+        LOGGER.exception(ex)
+        return JSONResponse({"error": str(ex)}, status_code=500)
+
+
+# TODO verify the safety of this call
+@app.get("/api/client/kill/{pid}")
+def kill(pid: str) -> JSONResponse:
+    """
+    Kills the client process with given PID.
+
+    :param pid: (str) the PID of the client to be killed.
+
+    :return: (JSONResponse) If successful, returns 200. If not successful, returns the appropriate
+        error code with a JSON with the format below:
+            {"error": <error message>}
+    """
+    try:
+        os.kill(int(pid), signal.SIGTERM)
+        LOGGER.info(f"Killed process with PID {pid}")
+        return JSONResponse(content={"status": "success"})
     except Exception as ex:
         LOGGER.exception(ex)
         return JSONResponse({"error": str(ex)}, status_code=500)

--- a/florist/api/db/entities.py
+++ b/florist/api/db/entities.py
@@ -218,39 +218,43 @@ class Job(BaseModel):
                 )
                 assert_updated_successfully(update_result)
 
-    async def set_log_file_paths(
-        self,
-        server_log_file_path: str,
-        client_log_file_paths: List[str],
-        database: AsyncIOMotorDatabase[Any],
-    ) -> None:
+    async def set_server_log_file_path(self, log_file_path: str, database: AsyncIOMotorDatabase[Any]) -> None:
         """
-        Save the server and clients' log file paths in the database under the current job's id.
+        Save the server's log file path in the database under the current job's id.
 
-        :param server_log_file_path: [str] the server log file path to be saved in the database.
-        :param client_log_file_paths: List[str] the list of client log file paths to be saved in the database.
+        :param log_file_path: (str) the file path to be saved in the database.
         :param database: (motor.motor_asyncio.AsyncIOMotorDatabase) The database where the job collection is stored.
         """
-        assert self.clients_info is not None and len(self.clients_info) == len(client_log_file_paths), (
-            "self.clients_info and client_log_file_paths must have the same length "
-            f"({'None' if self.clients_info is None else len(self.clients_info)}!={len(client_log_file_paths)})."
-        )
-
         job_collection = database[JOB_COLLECTION_NAME]
-
-        self.server_log_file_path = server_log_file_path
+        self.server_log_file_path = log_file_path
         update_result = await job_collection.update_one(
-            {"_id": self.id},
-            {"$set": {"server_log_file_path": server_log_file_path}},
+            {"_id": self.id}, {"$set": {"server_log_file_path": log_file_path}}
         )
         assert_updated_successfully(update_result)
 
-        for i in range(len(client_log_file_paths)):
-            self.clients_info[i].log_file_path = client_log_file_paths[i]
-            update_result = await job_collection.update_one(
-                {"_id": self.id}, {"$set": {f"clients_info.{i}.log_file_path": client_log_file_paths[i]}}
-            )
-            assert_updated_successfully(update_result)
+    async def set_client_log_file_path(
+        self,
+        client_index: int,
+        log_file_path: str,
+        database: AsyncIOMotorDatabase[Any],
+    ) -> None:
+        """
+        Save the clients' log file path in the database under the given client index and current job's id.
+
+        :param client_index: (str) the index of the client in the job.
+        :param log_file_path: (str) the path oof the client's log file.
+        :param database: (motor.motor_asyncio.AsyncIOMotorDatabase) The database where the job collection is stored.
+        """
+        assert self.clients_info is not None, "Job has no clients."
+        assert 0 <= client_index < len(self.clients_info), (
+            f"Client index {client_index} is invalid (total: {len(self.clients_info)})"
+        )
+
+        job_collection = database[JOB_COLLECTION_NAME]
+        update_result = await job_collection.update_one(
+            {"_id": self.id}, {"$set": {f"clients_info.{client_index}.log_file_path": log_file_path}}
+        )
+        assert_updated_successfully(update_result)
 
     async def set_pids(self, server_pid: str, client_pids: List[str], database: AsyncIOMotorDatabase[Any]) -> None:
         """

--- a/florist/api/db/entities.py
+++ b/florist/api/db/entities.py
@@ -83,6 +83,7 @@ class Job(BaseModel):
     redis_host: Optional[Annotated[str, Field(...)]]
     redis_port: Optional[Annotated[str, Field(...)]]
     clients_info: Optional[Annotated[List[ClientInfo], Field(...)]]
+    error_message: Optional[Annotated[str, Field(...)]]
 
     @classmethod
     async def find_by_id(cls, job_id: str, database: AsyncIOMotorDatabase[Any]) -> Optional["Job"]:
@@ -240,6 +241,18 @@ class Job(BaseModel):
             )
             assert_updated_successfully(update_result)
 
+    async def set_error_message(self, error_message: str, database: AsyncIOMotorDatabase[Any]) -> None:
+        """
+        Save an error message in the database under the current job's id.
+
+        :param error_message: (str) the error message to be saved in the database.
+        :param database: (motor.motor_asyncio.AsyncIOMotorDatabase) The database where the job collection is stored.
+        """
+        job_collection = database[JOB_COLLECTION_NAME]
+        self.error_message = error_message
+        update_result = await job_collection.update_one({"_id": self.id}, {"$set": {"error_message": error_message}})
+        assert_updated_successfully(update_result)
+
     class Config:
         """MongoDB config for the Job DB entity."""
 
@@ -268,6 +281,7 @@ class Job(BaseModel):
                         "pid": "123",
                     },
                 ],
+                "error_message": "Some plain text error message.",
             },
         }
 

--- a/florist/api/launchers/local.py
+++ b/florist/api/launchers/local.py
@@ -117,7 +117,7 @@ def launch_server(
     return server_process
 
 
-def launch_client(client: BasicClient, server_address: str, client_log_file_name: str) -> None:
+def launch_client(client: BasicClient, server_address: str, client_log_file_name: str) -> Process:
     """
     Spawn a process that starts FL client.
 
@@ -128,6 +128,7 @@ def launch_client(client: BasicClient, server_address: str, client_log_file_name
     """
     client_process = Process(target=start_client, args=(client, server_address, client_log_file_name))
     client_process.start()
+    return client_process
 
 
 def launch(

--- a/florist/api/routes/server/job.py
+++ b/florist/api/routes/server/job.py
@@ -1,12 +1,12 @@
 """FastAPI routes for the job."""
 
 import logging
-import requests
 import os
 import signal
 from datetime import datetime
 from typing import List, Union
 
+import requests
 from fastapi import APIRouter, Body, Request, status
 from fastapi.responses import JSONResponse
 
@@ -123,15 +123,16 @@ async def stop_job(job_id: str, request: Request) -> JSONResponse:
     job = await Job.find_by_id(job_id, request.app.database)
     try:
         assert job is not None, f"Job {job_id} not found"
+        assert job.clients_info is not None
 
         user_error_message = ""
         for client_info in job.clients_info:
-            response = requests.get(url=f"http://{client_info.service_address}/api/client/kill/{client_info.pid}")
+            response = requests.get(url=f"http://{client_info.service_address}/api/client/stop/{client_info.pid}")
             status_code = response.status_code
             if status_code != 200:
                 response_data = response.json()
-                msg = f"/api/client/kill returned {status_code} for client {client_info.uuid}: {response_data}."
                 user_error_message += f"Failed to stop client {client_info.uuid}: {response_data['error']}. "
+                msg = f"/api/client/stop returned {status_code} for client {client_info.uuid}: {response_data}."
                 LOGGER.error(msg)
 
         if not job.server_pid:

--- a/florist/api/routes/server/job.py
+++ b/florist/api/routes/server/job.py
@@ -135,7 +135,6 @@ async def stop_job(job_id: str, request: Request) -> JSONResponse:
         await job.set_status(JobStatus.FINISHED_WITH_ERROR, request.app.database)
         await job.set_error_message("Training job terminated manually.", request.app.database)
 
-
         return JSONResponse(content={"status": "success"})
     except AssertionError as assertion_e:
         return JSONResponse(content={"error": str(assertion_e)}, status_code=400)

--- a/florist/api/routes/server/job.py
+++ b/florist/api/routes/server/job.py
@@ -4,6 +4,7 @@ import logging
 import requests
 import os
 import signal
+from datetime import datetime
 from typing import List, Union
 
 from fastapi import APIRouter, Body, Request, status
@@ -143,7 +144,7 @@ async def stop_job(job_id: str, request: Request) -> JSONResponse:
                 user_error_message += f"Failed to stop server {job.server_uuid}: {str(e)}. "
 
         await job.set_status(JobStatus.FINISHED_WITH_ERROR, request.app.database)
-        user_error_message = "Training job terminated manually. " + user_error_message
+        user_error_message = f"Training job terminated manually on {datetime.now()}. {user_error_message}"
         await job.set_error_message(user_error_message, request.app.database)
 
         return JSONResponse(content={"status": "success"})

--- a/florist/api/routes/server/job.py
+++ b/florist/api/routes/server/job.py
@@ -136,7 +136,7 @@ async def stop_job(job_id: str, request: Request) -> JSONResponse:
                 LOGGER.error(msg)
 
         if not job.server_pid:
-            user_error_message += f"PID for server {job.server_uuid} is not valid: {job.server_pid}. "
+            user_error_message += f"PID for server {job.server_uuid} is empty or None."
         else:
             try:
                 os.kill(int(job.server_pid), signal.SIGTERM)

--- a/florist/api/routes/server/job.py
+++ b/florist/api/routes/server/job.py
@@ -1,5 +1,9 @@
 """FastAPI routes for the job."""
 
+import logging
+import requests
+import os
+import signal
 from typing import List, Union
 
 from fastapi import APIRouter, Body, Request, status
@@ -9,6 +13,8 @@ from florist.api.db.entities import MAX_RECORDS_TO_FETCH, Job, JobStatus
 
 
 router = APIRouter()
+
+LOGGER = logging.getLogger("uvicorn.error")
 
 
 @router.get(
@@ -94,6 +100,42 @@ async def change_job_status(job_id: str, status: JobStatus, request: Request) ->
     try:
         assert job_in_db is not None, f"Job {job_id} not found"
         await job_in_db.set_status(status, request.app.database)
+        return JSONResponse(content={"status": "success"})
+    except AssertionError as assertion_e:
+        return JSONResponse(content={"error": str(assertion_e)}, status_code=400)
+    except Exception as general_e:
+        return JSONResponse(content={"error": str(general_e)}, status_code=500)
+
+
+@router.post(path="/stop/{job_id}", response_description="Stops a job")
+async def stop_job(job_id: str, request: Request) -> JSONResponse:
+    """
+    Stop the job with the given ID. The job is stopped by killing all the clients and servers processes.
+
+    :param job_id: (str) The id of the job to stop.
+    :param request: (fastapi.Request) the FastAPI request object.
+
+    :return: (JSONResponse) If successful, returns 200. If not successful, returns response with status code 400
+        and body: {"error": <error message>}
+    """
+    job = await Job.find_by_id(job_id, request.app.database)
+    try:
+        assert job is not None, f"Job {job_id} not found"
+
+        for client_info in job.clients_info:
+            response = requests.get(url=f"http://{client_info.service_address}/api/client/kill/{client_info.pid}")
+            if response.status_code != 200:
+                # TODO figure out what to do here
+                LOGGER.error(f"/api/client/kill returned status {response.status} for client {client_info.uuid}.")
+                pass
+
+        os.kill(int(job.server_pid), signal.SIGTERM)
+        LOGGER.info(f"Killed process with PID {job.server_pid}")
+
+        await job.set_status(JobStatus.FINISHED_WITH_ERROR, request.app.database)
+        await job.set_error_message("Training job terminated manually.", request.app.database)
+
+
         return JSONResponse(content={"status": "success"})
     except AssertionError as assertion_e:
         return JSONResponse(content={"error": str(assertion_e)}, status_code=400)

--- a/florist/api/routes/server/training.py
+++ b/florist/api/routes/server/training.py
@@ -94,7 +94,6 @@ async def start(job_id: str, request: Request) -> JSONResponse:
 
         await job.set_uuids(server_uuid, client_uuids, request.app.database)
         await job.set_pids(str(server_process.pid), client_pids, request.app.database)
-        # TODO make this function
         await job.set_log_file_paths(server_log_file_path, client_log_file_paths, request.app.database)
 
         # Start the server training listener and client training listeners as threads to update

--- a/florist/api/routes/server/training.py
+++ b/florist/api/routes/server/training.py
@@ -94,6 +94,7 @@ async def start(job_id: str, request: Request) -> JSONResponse:
 
         await job.set_uuids(server_uuid, client_uuids, request.app.database)
         await job.set_pids(str(server_process.pid), client_pids, request.app.database)
+        # TODO make this function
         await job.set_log_file_paths(server_log_file_path, client_log_file_paths, request.app.database)
 
         # Start the server training listener and client training listeners as threads to update

--- a/florist/api/routes/server/training.py
+++ b/florist/api/routes/server/training.py
@@ -115,12 +115,14 @@ async def start(job_id: str, request: Request) -> JSONResponse:
     except AssertionError as err:
         if job is not None:
             await job.set_status(JobStatus.FINISHED_WITH_ERROR, request.app.database)
+            await job.set_error_message(str(err), request.app.database)
         return JSONResponse(content={"error": str(err)}, status_code=400)
 
     except Exception as ex:
         LOGGER.exception(ex)
         if job is not None:
             await job.set_status(JobStatus.FINISHED_WITH_ERROR, request.app.database)
+            await job.set_error_message(str(ex), request.app.database)
         return JSONResponse({"error": str(ex)}, status_code=500)
 
 

--- a/florist/api/routes/server/training.py
+++ b/florist/api/routes/server/training.py
@@ -96,9 +96,11 @@ async def start(job_id: str, request: Request) -> JSONResponse:
         # Start the server training listener and client training listeners as threads to update
         # the job's metrics and status once the training is done
         server_listener_thread = Thread(target=asyncio.run, args=(server_training_listener(job),))
+        server_listener_thread.daemon = True
         server_listener_thread.start()
         for client_info in job.clients_info:
             client_listener_thread = Thread(target=asyncio.run, args=(client_training_listener(job, client_info),))
+            client_listener_thread.daemon = True
             client_listener_thread.start()
 
         # Return the UUIDs

--- a/florist/app/jobs/details/page.tsx
+++ b/florist/app/jobs/details/page.tsx
@@ -327,6 +327,7 @@ export function JobProgressDetails({
         if (fitEndKey in metrics) {
             elapsedTime = getTimeString(Date.parse(metrics[fitEndKey]) - startDate);
         } else if (validStatuses[status] === validStatuses.IN_PROGRESS) {
+            // only estimate elapsed time if the job is in progress
             elapsedTime = getTimeString(Date.now() - startDate);
         }
     }

--- a/florist/app/jobs/details/page.tsx
+++ b/florist/app/jobs/details/page.tsx
@@ -224,9 +224,7 @@ export function JobProgressBar({
             validStatuses[status] !== validStatuses.FINISHED_SUCCESSFULLY &&
             validStatuses[status] !== validStatuses.FINISHED_WITH_ERROR
         ) {
-            if (progressPercent === 0) {
-                status = "NOT_STARTED";
-            } else if (progressPercent === 100) {
+            if (progressPercent === 100) {
                 status = "FINISHED_SUCCESSFULLY";
             } else {
                 status = "IN_PROGRESS";

--- a/florist/app/jobs/details/page.tsx
+++ b/florist/app/jobs/details/page.tsx
@@ -110,7 +110,7 @@ export function JobDetailsBody(): ReactElement {
                     {job.redis_port}
                 </div>
             </div>
-            {job.error_message ?
+            {job.error_message ? (
                 <div className="row pb-2 mb-2">
                     <div className="col-sm-2">
                         <strong className="text-dark">Error:</strong>
@@ -119,7 +119,7 @@ export function JobDetailsBody(): ReactElement {
                         {job.error_message}
                     </div>
                 </div>
-            : null}
+            ) : null}
 
             <JobProgressBar metrics={job.server_metrics} totalEpochs={totalEpochs} jobStatus={job.status} />
 
@@ -220,7 +220,10 @@ export function JobProgressBar({
     // the server status and progress percent
     let status = jobStatus;
     if (metricsJson.host_type === "client") {
-        if (validStatuses[status] !== validStatuses.FINISHED_SUCCESSFULLY && validStatuses[status] !== validStatuses.FINISHED_WITH_ERROR ) {
+        if (
+            validStatuses[status] !== validStatuses.FINISHED_SUCCESSFULLY &&
+            validStatuses[status] !== validStatuses.FINISHED_WITH_ERROR
+        ) {
             if (progressPercent === 0) {
                 status = "NOT_STARTED";
             } else if (progressPercent === 100) {
@@ -287,9 +290,9 @@ export function JobProgressBar({
                         </div>
                     </div>
                     <div className="row pb-2">
-                        {!collapsed ?
+                        {!collapsed ? (
                             <JobProgressDetails metrics={metricsJson} clientIndex={clientIndex} status={status} />
-                        : null}
+                        ) : null}
                     </div>
                 </div>
             </div>
@@ -300,11 +303,11 @@ export function JobProgressBar({
 export function JobProgressDetails({
     metrics,
     clientIndex,
-    status
+    status,
 }: {
     metrics: Object;
-    clientIndex: number,
-    status: string,
+    clientIndex: number;
+    status: string;
 }): ReactElement {
     if (!metrics) {
         return null;

--- a/florist/app/jobs/details/page.tsx
+++ b/florist/app/jobs/details/page.tsx
@@ -110,6 +110,16 @@ export function JobDetailsBody(): ReactElement {
                     {job.redis_port}
                 </div>
             </div>
+            {job.error_message ?
+                <div className="row pb-2 mb-2">
+                    <div className="col-sm-2">
+                        <strong className="text-dark">Error:</strong>
+                    </div>
+                    <div className="col-sm" id="job-details-redis-port">
+                        {job.error_message}
+                    </div>
+                </div>
+            : null}
 
             <JobProgressBar metrics={job.server_metrics} totalEpochs={totalEpochs} status={job.status} />
 

--- a/florist/app/jobs/details/page.tsx
+++ b/florist/app/jobs/details/page.tsx
@@ -133,7 +133,7 @@ export function JobDetailsBody(): ReactElement {
                 Component={JobDetailsClientsInfoTable}
                 title="Clients Configuration"
                 data={job.clients_info}
-                properties={{ totalEpochs }}
+                properties={{ totalEpochs, jobStatus: job.status }}
             />
         </div>
     );
@@ -216,18 +216,6 @@ export function JobProgressBar({
     }
     const progressWidth = progressPercent === 0 ? "100%" : `${progressPercent}%`;
 
-    // Clients will not have a status, so we need to set one based on the progress percent
-    if (!status) {
-        if (progressPercent === 0) {
-            status = "NOT_STARTED";
-        } else if (progressPercent === 100) {
-            status = "FINISHED_SUCCESSFULLY";
-        } else {
-            status = "IN_PROGRESS";
-        }
-        // TODO: add error status
-    }
-
     let progressBarClasses = "progress-bar progress-bar-striped";
     switch (String(validStatuses[status])) {
         case validStatuses.IN_PROGRESS:
@@ -284,7 +272,9 @@ export function JobProgressBar({
                         </div>
                     </div>
                     <div className="row pb-2">
-                        {!collapsed ? <JobProgressDetails metrics={metricsJson} clientIndex={clientIndex} /> : null}
+                        {!collapsed ?
+                            <JobProgressDetails metrics={metricsJson} clientIndex={clientIndex} status={status} />
+                        : null}
                     </div>
                 </div>
             </div>
@@ -292,7 +282,15 @@ export function JobProgressBar({
     );
 }
 
-export function JobProgressDetails({ metrics, clientIndex }: { metrics: Object; clientIndex: number }): ReactElement {
+export function JobProgressDetails({
+    metrics,
+    clientIndex,
+    status
+}: {
+    metrics: Object;
+    clientIndex: number,
+    status: string,
+}): ReactElement {
     if (!metrics) {
         return null;
     }
@@ -309,7 +307,7 @@ export function JobProgressDetails({ metrics, clientIndex }: { metrics: Object; 
     }
 
     let elapsedTime = "";
-    if (fitStartKey in metrics) {
+    if (fitStartKey in metrics && status == validStatuses.IN_PROGRESS) {
         const startDate = Date.parse(metrics[fitStartKey]);
         const endDate = fitEndKey in metrics ? Date.parse(metrics[fitEndKey]) : Date.now();
         elapsedTime = getTimeString(endDate - startDate);
@@ -679,6 +677,7 @@ export function JobDetailsClientsInfoTable({
                                             metrics={clientInfo.metrics}
                                             totalEpochs={properties.totalEpochs}
                                             clientIndex={i}
+                                            status={properties.jobStatus}
                                         />
                                     </span>
                                 </div>

--- a/florist/app/jobs/details/page.tsx
+++ b/florist/app/jobs/details/page.tsx
@@ -115,7 +115,7 @@ export function JobDetailsBody(): ReactElement {
                     <div className="col-sm-2">
                         <strong className="text-dark">Error:</strong>
                     </div>
-                    <div className="col-sm" id="job-details-redis-port">
+                    <div className="col-sm" id="job-details-error-message">
                         {job.error_message}
                     </div>
                 </div>

--- a/florist/app/jobs/page.tsx
+++ b/florist/app/jobs/page.tsx
@@ -139,19 +139,44 @@ export function JobDetailsButton({
 }
 
 export function StopJobButton({ rowId, jobId }: { rowId: number, jobId: string }): ReactElement {
+    const { post, response, isLoading, error } = usePost();
+    const handleClickStopJobButton = async () => {
+        event.preventDefault();
+
+        if (isLoading) {
+            // Preventing double submit if already in progress
+            return;
+        }
+        const url = `/api/server/job/stop/${jobId}`;
+        await post(url, JSON.stringify({}));
+    };
+
+    // Only refresh the job data if there is an error or response
+    useEffect(() => refreshJobsByJobStatus(Object.keys(validStatuses)), [error, response]);
+
+    let buttonClasses = "btn btn-sm mb-0 ";
+    if (isLoading || response) {
+        // If is loading or if a successful response has been received,
+        // disable the button to avoid double submit.
+        buttonClasses += "btn-secondary disabled";
+    } else {
+        buttonClasses += "btn-primary";
+    }
+
     return (
         <div>
-            <Link
-                data-testid={`job-details-button-stop-${rowId}`}
-                className="btn btn-primary btn-sm mb-0"
+            <button
+                data-testid={`stop-training-button-${rowId}`}
+                onClick={handleClickStopJobButton}
+                className={buttonClasses}
                 title="Stop"
-                href={{
-                    pathname: "jobs/stop",
-                    query: { id: jobId },
-                }}
             >
-                <i className="material-icons text-sm">stop</i>
-            </Link>
+                {isLoading || response ? (
+                    <span class="spinner-border spinner-border-sm align-middle"></span>
+                ) : (
+                    <i className="material-icons text-sm">stop</i>
+                )}
+            </button>
         </div>
     );
 }

--- a/florist/app/jobs/page.tsx
+++ b/florist/app/jobs/page.tsx
@@ -138,7 +138,7 @@ export function JobDetailsButton({
     );
 }
 
-export function StopJobButton({ rowId, jobId }: { rowId: number, jobId: string }): ReactElement {
+export function StopJobButton({ rowId, jobId }: { rowId: number; jobId: string }): ReactElement {
     const { post, response, isLoading, error } = usePost();
 
     const handleClickStopJobButton = async () => {
@@ -296,11 +296,11 @@ export function TableRow({
                 <JobDetailsButton rowId={rowId} jobId={jobId} status={status} />
             </td>
             <td>
-                {validStatuses[status] === "In Progress" ?
+                {validStatuses[status] === "In Progress" ? (
                     <StopJobButton rowId={rowId} jobId={jobId} />
-                :validStatuses[status] === "Not Started" ?
+                ) : validStatuses[status] === "Not Started" ? (
                     <StartJobButton rowId={rowId} jobId={jobId} />
-                :null}
+                ) : null}
             </td>
         </tr>
     );

--- a/florist/app/jobs/page.tsx
+++ b/florist/app/jobs/page.tsx
@@ -141,8 +141,6 @@ export function JobDetailsButton({
 export function StopJobButton({ rowId, jobId }: { rowId: number, jobId: string }): ReactElement {
     const { post, response, isLoading, error } = usePost();
 
-    console.log(`response: ${response}, row: ${rowId}`)
-
     const handleClickStopJobButton = async () => {
         event.preventDefault();
 

--- a/florist/app/jobs/page.tsx
+++ b/florist/app/jobs/page.tsx
@@ -103,7 +103,7 @@ export function StartJobButton({ rowId, jobId }: { rowId: number; jobId: string 
                 title="Start"
             >
                 {isLoading || response ? (
-                    <span class="spinner-border spinner-border-sm align-middle"></span>
+                    <span className="spinner-border spinner-border-sm align-middle"></span>
                 ) : (
                     <i className="material-icons text-sm">play_circle_outline</i>
                 )}
@@ -140,6 +140,9 @@ export function JobDetailsButton({
 
 export function StopJobButton({ rowId, jobId }: { rowId: number, jobId: string }): ReactElement {
     const { post, response, isLoading, error } = usePost();
+
+    console.log(`response: ${response}, row: ${rowId}`)
+
     const handleClickStopJobButton = async () => {
         event.preventDefault();
 
@@ -155,9 +158,8 @@ export function StopJobButton({ rowId, jobId }: { rowId: number, jobId: string }
     useEffect(() => refreshJobsByJobStatus(Object.keys(validStatuses)), [error, response]);
 
     let buttonClasses = "btn btn-sm mb-0 ";
-    if (isLoading || response) {
-        // If is loading or if a successful response has been received,
-        // disable the button to avoid double submit.
+    if (isLoading) {
+        // If is loading disable the button to avoid double submit.
         buttonClasses += "btn-secondary disabled";
     } else {
         buttonClasses += "btn-primary";
@@ -171,8 +173,8 @@ export function StopJobButton({ rowId, jobId }: { rowId: number, jobId: string }
                 className={buttonClasses}
                 title="Stop"
             >
-                {isLoading || response ? (
-                    <span class="spinner-border spinner-border-sm align-middle"></span>
+                {isLoading ? (
+                    <span className="spinner-border spinner-border-sm align-middle"></span>
                 ) : (
                     <i className="material-icons text-sm">stop</i>
                 )}

--- a/florist/app/jobs/page.tsx
+++ b/florist/app/jobs/page.tsx
@@ -126,13 +126,31 @@ export function JobDetailsButton({
             <Link
                 data-testid={`job-details-button-${status}-${rowId}`}
                 className="btn btn-primary btn-sm mb-0"
-                alt="Details"
+                title="Details"
                 href={{
                     pathname: "jobs/details",
                     query: { id: jobId },
                 }}
             >
                 <i className="material-icons text-sm">settings</i>
+            </Link>
+        </div>
+    );
+}
+
+export function StopJobButton({ rowId, jobId }: { rowId: number, jobId: string }): ReactElement {
+    return (
+        <div>
+            <Link
+                data-testid={`job-details-button-stop-${rowId}`}
+                className="btn btn-primary btn-sm mb-0"
+                title="Stop"
+                href={{
+                    pathname: "jobs/stop",
+                    query: { id: jobId },
+                }}
+            >
+                <i className="material-icons text-sm">stop</i>
             </Link>
         </div>
     );
@@ -174,6 +192,7 @@ export function StatusTable({ data, status }: { data: Array<JobData>; status: St
                                 <th className="text-uppercase text-secondary text-xxs font-weight-bolder opacity-7">
                                     Client Service Addresses
                                 </th>
+                                <th width="50"></th>
                                 <th width="50"></th>
                                 <th width="100"></th>
                             </tr>
@@ -251,7 +270,13 @@ export function TableRow({
             <td>
                 <JobDetailsButton rowId={rowId} jobId={jobId} status={status} />
             </td>
-            <td>{validStatuses[status] === "Not Started" ? <StartJobButton rowId={rowId} jobId={jobId} /> : null}</td>
+            <td>
+                {validStatuses[status] === "In Progress" ?
+                    <StopJobButton rowId={rowId} jobId={jobId} />
+                :validStatuses[status] === "Not Started" ?
+                    <StartJobButton rowId={rowId} jobId={jobId} />
+                :null}
+            </td>
         </tr>
     );
 }

--- a/florist/tests/integration/api/db/test_entities.py
+++ b/florist/tests/integration/api/db/test_entities.py
@@ -215,37 +215,36 @@ async def test_set_client_metrics_fail_update_result(mock_request) -> None:
         )
 
 
-async def test_set_log_file_path_success(mock_request) -> None:
+async def test_set_server_log_file_path_success(mock_request) -> None:
     test_job = get_test_job()
     result_id = await test_job.create(mock_request.app.database)
     test_job.id = result_id
     test_job.clients_info[0].id = ANY
     test_job.clients_info[1].id = ANY
 
-    test_server_log_file_path = "test-server-log-file-path"
-    test_client_log_file_path_1 = "test-server-log-file-path-1"
-    test_client_log_file_path_2 = "test-server-log-file-path-2"
+    test_log_file_path = "test/log/file/path.log"
 
-    await test_job.set_log_file_paths(
-        test_server_log_file_path,
-        [test_client_log_file_path_1, test_client_log_file_path_2],
-        mock_request.app.database,
-    )
+    await test_job.set_server_log_file_path(test_log_file_path, mock_request.app.database)
 
     result_job = await Job.find_by_id(result_id, mock_request.app.database)
-    test_job.server_log_file_path = test_server_log_file_path
-    test_job.clients_info[0].log_file_path = test_client_log_file_path_1
-    test_job.clients_info[1].log_file_path = test_client_log_file_path_2
+    test_job.server_log_file_path = test_log_file_path
     assert result_job == test_job
 
 
-async def test_set_set_log_file_path_assertion_error(mock_request) -> None:
+async def test_set_client_log_file_path_success(mock_request) -> None:
     test_job = get_test_job()
-    await test_job.create(mock_request.app.database)
+    result_id = await test_job.create(mock_request.app.database)
+    test_job.id = result_id
+    test_job.clients_info[0].id = ANY
+    test_job.clients_info[1].id = ANY
 
-    error_message = "self.clients_info and client_log_file_paths must have the same length (2!=1)"
-    with raises(AssertionError, match=re.escape(error_message)):
-        await test_job.set_log_file_paths("test", ["test"], mock_request.app.database)
+    test_log_file_path = "test/log/file/path.log"
+
+    await test_job.set_client_log_file_path(1, test_log_file_path, mock_request.app.database)
+
+    result_job = await Job.find_by_id(result_id, mock_request.app.database)
+    test_job.clients_info[1].log_file_path = test_log_file_path
+    assert result_job == test_job
 
 
 async def test_set_pid_success(mock_request) -> None:

--- a/florist/tests/integration/api/db/test_entities.py
+++ b/florist/tests/integration/api/db/test_entities.py
@@ -215,36 +215,37 @@ async def test_set_client_metrics_fail_update_result(mock_request) -> None:
         )
 
 
-async def test_set_server_log_file_path_success(mock_request) -> None:
+async def test_set_log_file_path_success(mock_request) -> None:
     test_job = get_test_job()
     result_id = await test_job.create(mock_request.app.database)
     test_job.id = result_id
     test_job.clients_info[0].id = ANY
     test_job.clients_info[1].id = ANY
 
-    test_log_file_path = "test/log/file/path.log"
+    test_server_log_file_path = "test-server-log-file-path"
+    test_client_log_file_path_1 = "test-server-log-file-path-1"
+    test_client_log_file_path_2 = "test-server-log-file-path-2"
 
-    await test_job.set_server_log_file_path(test_log_file_path, mock_request.app.database)
+    await test_job.set_log_file_paths(
+        test_server_log_file_path,
+        [test_client_log_file_path_1, test_client_log_file_path_2],
+        mock_request.app.database,
+    )
 
     result_job = await Job.find_by_id(result_id, mock_request.app.database)
-    test_job.server_log_file_path = test_log_file_path
+    test_job.server_log_file_path = test_server_log_file_path
+    test_job.clients_info[0].log_file_path = test_client_log_file_path_1
+    test_job.clients_info[1].log_file_path = test_client_log_file_path_2
     assert result_job == test_job
 
 
-async def test_set_client_log_file_path_success(mock_request) -> None:
+async def test_set_set_log_file_path_assertion_error(mock_request) -> None:
     test_job = get_test_job()
-    result_id = await test_job.create(mock_request.app.database)
-    test_job.id = result_id
-    test_job.clients_info[0].id = ANY
-    test_job.clients_info[1].id = ANY
+    await test_job.create(mock_request.app.database)
 
-    test_log_file_path = "test/log/file/path.log"
-
-    await test_job.set_client_log_file_path(1, test_log_file_path, mock_request.app.database)
-
-    result_job = await Job.find_by_id(result_id, mock_request.app.database)
-    test_job.clients_info[1].log_file_path = test_log_file_path
-    assert result_job == test_job
+    error_message = "self.clients_info and client_log_file_paths must have the same length (2!=1)"
+    with raises(AssertionError, match=re.escape(error_message)):
+        await test_job.set_log_file_paths("test", ["test"], mock_request.app.database)
 
 
 async def test_set_pid_success(mock_request) -> None:

--- a/florist/tests/integration/api/routes/server/test_job.py
+++ b/florist/tests/integration/api/routes/server/test_job.py
@@ -26,6 +26,8 @@ async def test_new_job(mock_request) -> None:
         "clients_info": None,
         "server_metrics": None,
         "server_uuid": None,
+        "server_pid": None,
+        "error_message": None,
     }
 
     test_job = Job(
@@ -39,6 +41,8 @@ async def test_new_job(mock_request) -> None:
         redis_port="test-redis-port",
         server_metrics="test-server-metrics",
         server_uuid="test-server-uuid",
+        server_pid="test-server-pid",
+        error_message="test-error-message",
         clients_info=[
             ClientInfo(
                 client=Client.MNIST,
@@ -48,6 +52,7 @@ async def test_new_job(mock_request) -> None:
                 redis_port="test-redis-port-1",
                 metrics="test-client-metrics-1",
                 uuid="test-client-uuid-1",
+                pid="test-client-pid-1",
             ),
             ClientInfo(
                 client=Client.MNIST,
@@ -55,8 +60,9 @@ async def test_new_job(mock_request) -> None:
                 data_path="test/data/path-2",
                 redis_host="test-redis-host-2",
                 redis_port="test-redis-port-2",
-                metrics="test-client-metrics-1",
-                uuid="test-client-uuid-1",
+                metrics="test-client-metrics-2",
+                uuid="test-client-uuid-2",
+                pid="test-client-pid-2",
             ),
         ]
     )
@@ -73,6 +79,8 @@ async def test_new_job(mock_request) -> None:
         "redis_port": test_job.redis_port,
         "server_uuid": test_job.server_uuid,
         "server_metrics": test_job.server_metrics,
+        "server_pid": test_job.server_pid,
+        "error_message": test_job.error_message,
         "clients_info": [
             {
                 "_id": ANY,
@@ -83,6 +91,7 @@ async def test_new_job(mock_request) -> None:
                 "redis_port": test_job.clients_info[0].redis_port,
                 "uuid": test_job.clients_info[0].uuid,
                 "metrics": test_job.clients_info[0].metrics,
+                "pid": test_job.clients_info[0].pid,
             }, {
                 "_id": ANY,
                 "client": test_job.clients_info[1].client.value,
@@ -92,6 +101,7 @@ async def test_new_job(mock_request) -> None:
                 "redis_port": test_job.clients_info[1].redis_port,
                 "uuid": test_job.clients_info[1].uuid,
                 "metrics": test_job.clients_info[1].metrics,
+                "pid": test_job.clients_info[1].pid,
             },
         ],
     }
@@ -109,6 +119,8 @@ async def test_list_jobs_with_status(mock_request) -> None:
         redis_port="test-redis-port1",
         server_metrics="test-server-metrics1",
         server_uuid="test-server-uuid1",
+        server_pid="test-server-pid1",
+        error_message="test-error-message1",
         clients_info=[
             ClientInfo(
                 client=Client.MNIST,
@@ -118,6 +130,7 @@ async def test_list_jobs_with_status(mock_request) -> None:
                 redis_port="test-redis-port-1-1",
                 metrics="test-client-metrics-1-1",
                 uuid="test-client-uuid-1-1",
+                pid="test-client-pid-1-1",
             ),
             ClientInfo(
                 client=Client.MNIST,
@@ -127,6 +140,7 @@ async def test_list_jobs_with_status(mock_request) -> None:
                 redis_port="test-redis-port-2-1",
                 metrics="test-client-metrics-2-1",
                 uuid="test-client-uuid-2-1",
+                pid="test-client-pid-2-1",
             ),
         ]
     )
@@ -142,6 +156,8 @@ async def test_list_jobs_with_status(mock_request) -> None:
         redis_port="test-redis-port2",
         server_metrics="test-server-metrics2",
         server_uuid="test-server-uuid2",
+        server_pid="test-server-pid2",
+        error_message="test-error-message2",
         clients_info=[
             ClientInfo(
                 client=Client.MNIST,
@@ -151,6 +167,7 @@ async def test_list_jobs_with_status(mock_request) -> None:
                 redis_port="test-redis-port-1-2",
                 metrics="test-client-metrics-1-2",
                 uuid="test-client-uuid-1-2",
+                pid="test-client-pid-1-2",
             ),
             ClientInfo(
                 client=Client.MNIST,
@@ -160,6 +177,7 @@ async def test_list_jobs_with_status(mock_request) -> None:
                 redis_port="test-redis-port-2-2",
                 metrics="test-client-metrics-2-2",
                 uuid="test-client-uuid-2-2",
+                pid="test-client-pid-2-2",
             ),
         ]
     )
@@ -175,6 +193,8 @@ async def test_list_jobs_with_status(mock_request) -> None:
         redis_port="test-redis-port3",
         server_metrics="test-server-metrics3",
         server_uuid="test-server-uuid3",
+        server_pid="test-server-pid3",
+        error_message="test-error-message3",
         clients_info=[
             ClientInfo(
                 client=Client.MNIST,
@@ -184,6 +204,7 @@ async def test_list_jobs_with_status(mock_request) -> None:
                 redis_port="test-redis-port-1-3",
                 metrics="test-client-metrics-1-3",
                 uuid="test-client-uuid-1-3",
+                pid="test-client-pid-1-3",
             ),
             ClientInfo(
                 client=Client.MNIST,
@@ -193,6 +214,7 @@ async def test_list_jobs_with_status(mock_request) -> None:
                 redis_port="test-redis-port-2-3",
                 metrics="test-client-metrics-2-3",
                 uuid="test-client-uuid-2-3",
+                pid="test-client-pid-2-3",
             ),
         ]
     )
@@ -208,6 +230,8 @@ async def test_list_jobs_with_status(mock_request) -> None:
         redis_port="test-redis-port4",
         server_metrics="test-server-metrics4",
         server_uuid="test-server-uuid4",
+        server_pid="test-server-pid4",
+        error_message="test-error-message4",
         clients_info=[
             ClientInfo(
                 client=Client.MNIST,
@@ -217,6 +241,7 @@ async def test_list_jobs_with_status(mock_request) -> None:
                 redis_port="test-redis-port-1-4",
                 metrics="test-client-metrics-1-4",
                 uuid="test-client-uuid-1-4",
+                pid="test-client-pid-1-4",
             ),
             ClientInfo(
                 client=Client.MNIST,
@@ -226,6 +251,7 @@ async def test_list_jobs_with_status(mock_request) -> None:
                 redis_port="test-redis-port-2-4",
                 metrics="test-client-metrics-2-4",
                 uuid="test-client-uuid-2-4",
+                pid="test-client-pid-2-4",
             ),
         ]
     )
@@ -255,6 +281,8 @@ async def test_list_jobs_with_status(mock_request) -> None:
         "redis_port": test_job1.redis_port,
         "server_metrics": test_job1.server_metrics,
         "server_uuid": test_job1.server_uuid,
+        "server_pid": test_job1.server_pid,
+        "error_message": test_job1.error_message,
         "clients_info": [
             {
                 "_id": ANY,
@@ -265,6 +293,7 @@ async def test_list_jobs_with_status(mock_request) -> None:
                 "redis_port": test_job1.clients_info[0].redis_port,
                 "metrics": test_job1.clients_info[0].metrics,
                 "uuid": test_job1.clients_info[0].uuid,
+                "pid": test_job1.clients_info[0].pid,
             }, {
                 "_id": ANY,
                 "client": test_job1.clients_info[1].client.value,
@@ -274,6 +303,7 @@ async def test_list_jobs_with_status(mock_request) -> None:
                 "redis_port": test_job1.clients_info[1].redis_port,
                 "metrics": test_job1.clients_info[1].metrics,
                 "uuid": test_job1.clients_info[1].uuid,
+                "pid": test_job1.clients_info[1].pid,
             },
         ],
     }
@@ -289,6 +319,8 @@ async def test_list_jobs_with_status(mock_request) -> None:
         "redis_port": test_job2.redis_port,
         "server_metrics": test_job2.server_metrics,
         "server_uuid": test_job2.server_uuid,
+        "server_pid": test_job2.server_pid,
+        "error_message": test_job2.error_message,
         "clients_info": [
             {
                 "_id": ANY,
@@ -299,6 +331,7 @@ async def test_list_jobs_with_status(mock_request) -> None:
                 "redis_port": test_job2.clients_info[0].redis_port,
                 "metrics": test_job2.clients_info[0].metrics,
                 "uuid": test_job2.clients_info[0].uuid,
+                "pid": test_job2.clients_info[0].pid,
             }, {
                 "_id": ANY,
                 "client": test_job2.clients_info[1].client.value,
@@ -308,6 +341,7 @@ async def test_list_jobs_with_status(mock_request) -> None:
                 "redis_port": test_job2.clients_info[1].redis_port,
                 "metrics": test_job2.clients_info[1].metrics,
                 "uuid": test_job2.clients_info[1].uuid,
+                "pid": test_job2.clients_info[1].pid,
             },
         ],
     }
@@ -323,6 +357,8 @@ async def test_list_jobs_with_status(mock_request) -> None:
         "redis_port": test_job3.redis_port,
         "server_metrics": test_job3.server_metrics,
         "server_uuid": test_job3.server_uuid,
+        "server_pid": test_job3.server_pid,
+        "error_message": test_job3.error_message,
         "clients_info": [
             {
                 "_id": ANY,
@@ -333,6 +369,7 @@ async def test_list_jobs_with_status(mock_request) -> None:
                 "redis_port": test_job3.clients_info[0].redis_port,
                 "metrics": test_job3.clients_info[0].metrics,
                 "uuid": test_job3.clients_info[0].uuid,
+                "pid": test_job3.clients_info[0].pid,
             }, {
                 "_id": ANY,
                 "client": test_job3.clients_info[1].client.value,
@@ -342,6 +379,7 @@ async def test_list_jobs_with_status(mock_request) -> None:
                 "redis_port": test_job3.clients_info[1].redis_port,
                 "metrics": test_job3.clients_info[1].metrics,
                 "uuid": test_job3.clients_info[1].uuid,
+                "pid": test_job3.clients_info[1].pid,
             },
         ],
     }
@@ -357,6 +395,8 @@ async def test_list_jobs_with_status(mock_request) -> None:
         "redis_port": test_job4.redis_port,
         "server_metrics": test_job4.server_metrics,
         "server_uuid": test_job4.server_uuid,
+        "server_pid": test_job4.server_pid,
+        "error_message": test_job4.error_message,
         "clients_info": [
             {
                 "_id": ANY,
@@ -367,6 +407,7 @@ async def test_list_jobs_with_status(mock_request) -> None:
                 "redis_port": test_job4.clients_info[0].redis_port,
                 "metrics": test_job4.clients_info[0].metrics,
                 "uuid": test_job4.clients_info[0].uuid,
+                "pid": test_job4.clients_info[0].pid,
             }, {
                 "_id": ANY,
                 "client": test_job4.clients_info[1].client.value,
@@ -376,6 +417,7 @@ async def test_list_jobs_with_status(mock_request) -> None:
                 "redis_port": test_job4.clients_info[1].redis_port,
                 "metrics": test_job4.clients_info[1].metrics,
                 "uuid": test_job4.clients_info[1].uuid,
+                "pid": test_job4.clients_info[1].pid,
             },
         ],
     }

--- a/florist/tests/unit/api/routes/server/test_job.py
+++ b/florist/tests/unit/api/routes/server/test_job.py
@@ -117,6 +117,7 @@ async def test_change_job_status_failure_in_set_status(mock_find_by_id: Mock) ->
 @patch("florist.api.routes.server.job.requests")
 @patch("florist.api.routes.server.job.os.kill")
 async def test_stop_job_success(mock_kill: Mock, mock_requests: Mock, mock_find_by_id: Mock) -> None:
+    test_job_id = "test-job-id"
     test_pid = 1234
     test_clients = [
         ClientInfo(service_address="test-service-address-1", pid="test-pid-1", client=Client.MNIST, data_path="", redis_host="", redis_port=""),
@@ -135,21 +136,129 @@ async def test_stop_job_success(mock_kill: Mock, mock_requests: Mock, mock_find_
     mock_response.status_code = 200
     mock_requests.get.return_value = mock_response
 
-    test_id = "test_id"
+    response = await stop_job(test_job_id, mock_request)
 
-    response = await stop_job(test_id, mock_request)
-
-    mock_find_by_id.assert_called_once_with(test_id, mock_request.app.database)
+    mock_find_by_id.assert_called_once_with(test_job_id, mock_request.app.database)
     mock_kill.assert_called_once_with(test_pid, signal.SIGTERM)
     mock_job.set_status.assert_called_once_with(JobStatus.FINISHED_WITH_ERROR, mock_request.app.database)
     mock_job.set_error_message(f"Training job terminated manually on {datetime.now()}", mock_request.app.database)
     mock_requests.get.assert_has_calls([
-        call(url=f"http://{test_clients[0].service_address}/api/client/kill/{test_clients[0].pid}"),
-        call(url=f"http://{test_clients[1].service_address}/api/client/kill/{test_clients[1].pid}"),
+        call(url=f"http://{test_clients[0].service_address}/api/client/stop/{test_clients[0].pid}"),
+        call(url=f"http://{test_clients[1].service_address}/api/client/stop/{test_clients[1].pid}"),
     ])
 
     assert isinstance(response, JSONResponse)
     assert response.status_code == 200
     assert json.loads(response.body.decode("utf-8")) == {"status": "success"}
 
-# TODO test failure cases
+
+@freeze_time("2012-12-11 10:09:08")
+@patch("florist.api.db.entities.Job.find_by_id")
+@patch("florist.api.routes.server.job.requests")
+@patch("florist.api.routes.server.job.os.kill")
+async def test_stop_job_fail_stop_client(mock_kill: Mock, mock_requests: Mock, mock_find_by_id: Mock) -> None:
+    test_job_id = "test-job-id"
+    test_pid = 1234
+    test_clients = [
+        ClientInfo(uuid="test-client-uuid-1", service_address="test-service-address-1", pid="test-pid-1", client=Client.MNIST, data_path="", redis_host="", redis_port=""),
+        ClientInfo(uuid="test-client-uuid-1", service_address="test-service-address-2", pid="test-pid-2", client=Client.MNIST, data_path="", redis_host="", redis_port=""),
+    ]
+    test_error = "test-error"
+
+    mock_job = Mock()
+    mock_job.server_pid = test_pid
+    mock_job.clients_info = test_clients
+    mock_job.set_status = AsyncMock()
+    mock_job.set_error_message = AsyncMock()
+    mock_find_by_id.return_value = mock_job
+    mock_request = Mock()
+    mock_request.app.database = Mock()
+    mock_response = Mock()
+    mock_response.status_code = 500
+    mock_response.json.return_value = {"error": test_error}
+    mock_requests.get.return_value = mock_response
+
+    response = await stop_job(test_job_id, mock_request)
+
+    mock_find_by_id.assert_called_once_with(test_job_id, mock_request.app.database)
+    mock_kill.assert_called_once_with(test_pid, signal.SIGTERM)
+    mock_job.set_status.assert_called_once_with(JobStatus.FINISHED_WITH_ERROR, mock_request.app.database)
+    mock_requests.get.assert_has_calls([
+        call(url=f"http://{test_clients[0].service_address}/api/client/stop/{test_clients[0].pid}"),
+        call(url=f"http://{test_clients[1].service_address}/api/client/stop/{test_clients[1].pid}"),
+    ], any_order=True)
+    mock_job.set_error_message(
+        (
+            f"Training job terminated manually on {datetime.now()}",
+            f"Failed to stop client {test_clients[0].uuid}: {test_error}",
+            f"Failed to stop client {test_clients[1].uuid}: {test_error}",
+        ),
+        mock_request.app.database,
+    )
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 200
+    assert json.loads(response.body.decode("utf-8")) == {"status": "success"}
+
+
+@freeze_time("2012-12-11 10:09:08")
+@patch("florist.api.db.entities.Job.find_by_id")
+@patch("florist.api.routes.server.job.requests")
+@patch("florist.api.routes.server.job.os.kill")
+async def test_stop_job_fail_stop_server(_: Mock, mock_requests: Mock, mock_find_by_id: Mock) -> None:
+    test_job_id = "test-job-id"
+    test_server_uuid = "test-server-uuid"
+    test_pid = "incorrect-pid"
+    test_clients = [
+        ClientInfo(service_address="test-service-address-1", pid="test-pid-1", client=Client.MNIST, data_path="", redis_host="", redis_port=""),
+        ClientInfo(service_address="test-service-address-2", pid="test-pid-2", client=Client.MNIST, data_path="", redis_host="", redis_port=""),
+    ]
+
+    mock_job = Mock()
+    mock_job.server_uuid = test_server_uuid
+    mock_job.server_pid = test_pid
+    mock_job.clients_info = test_clients
+    mock_job.set_status = AsyncMock()
+    mock_job.set_error_message = AsyncMock()
+    mock_find_by_id.return_value = mock_job
+    mock_request = Mock()
+    mock_request.app.database = Mock()
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_requests.get.return_value = mock_response
+
+    response = await stop_job(test_job_id, mock_request)
+
+    mock_find_by_id.assert_called_once_with(test_job_id, mock_request.app.database)
+    mock_job.set_status.assert_called_once_with(JobStatus.FINISHED_WITH_ERROR, mock_request.app.database)
+    mock_requests.get.assert_has_calls([
+        call(url=f"http://{test_clients[0].service_address}/api/client/stop/{test_clients[0].pid}"),
+        call(url=f"http://{test_clients[1].service_address}/api/client/stop/{test_clients[1].pid}"),
+    ])
+    mock_job.set_error_message(
+        (
+            f"Training job terminated manually on {datetime.now()}",
+            f"Failed to stop server {test_server_uuid}: invalid literal for int() with base 10: '{test_pid}'",
+        ),
+        mock_request.app.database,
+    )
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 200
+    assert json.loads(response.body.decode("utf-8")) == {"status": "success"}
+
+
+@patch("florist.api.db.entities.Job.find_by_id")
+async def test_stop_job_assertion_error(mock_find_by_id: Mock) -> None:
+    test_job_id = "test-job-id"
+    mock_find_by_id.return_value = None
+    mock_request = Mock()
+    mock_request.app.database = Mock()
+
+    response = await stop_job(test_job_id, mock_request)
+
+    mock_find_by_id.assert_called_once_with(test_job_id, mock_request.app.database)
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 400
+    assert json.loads(response.body.decode("utf-8")) == {"error": f"Job {test_job_id} not found"}

--- a/florist/tests/unit/api/routes/server/test_job.py
+++ b/florist/tests/unit/api/routes/server/test_job.py
@@ -1,10 +1,14 @@
 import json
+import signal
+from datetime import datetime
 
-from unittest.mock import patch, Mock, AsyncMock
+from unittest.mock import patch, Mock, AsyncMock, call
 from fastapi.responses import JSONResponse
+from freezegun import freeze_time
 
-from florist.api.routes.server.job import change_job_status, get_job
-from florist.api.db.entities import JobStatus
+from florist.api.clients.common import Client
+from florist.api.routes.server.job import change_job_status, get_job, stop_job
+from florist.api.db.entities import JobStatus, ClientInfo
 
 
 @patch("florist.api.db.entities.Job.find_by_id")
@@ -106,3 +110,46 @@ async def test_change_job_status_failure_in_set_status(mock_find_by_id: Mock) ->
     assert isinstance(response, JSONResponse)
     assert response.status_code == 500
     assert json.loads(response.body.decode("utf-8")) == {"error": "Test Error"}
+
+
+@freeze_time("2012-12-11 10:09:08")
+@patch("florist.api.db.entities.Job.find_by_id")
+@patch("florist.api.routes.server.job.requests")
+@patch("florist.api.routes.server.job.os.kill")
+async def test_stop_job_success(mock_kill: Mock, mock_requests: Mock, mock_find_by_id: Mock) -> None:
+    test_pid = 1234
+    test_clients = [
+        ClientInfo(service_address="test-service-address-1", pid="test-pid-1", client=Client.MNIST, data_path="", redis_host="", redis_port=""),
+        ClientInfo(service_address="test-service-address-2", pid="test-pid-2", client=Client.MNIST, data_path="", redis_host="", redis_port=""),
+    ]
+
+    mock_job = Mock()
+    mock_job.server_pid = test_pid
+    mock_job.clients_info = test_clients
+    mock_job.set_status = AsyncMock()
+    mock_job.set_error_message = AsyncMock()
+    mock_find_by_id.return_value = mock_job
+    mock_request = Mock()
+    mock_request.app.database = Mock()
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_requests.get.return_value = mock_response
+
+    test_id = "test_id"
+
+    response = await stop_job(test_id, mock_request)
+
+    mock_find_by_id.assert_called_once_with(test_id, mock_request.app.database)
+    mock_kill.assert_called_once_with(test_pid, signal.SIGTERM)
+    mock_job.set_status.assert_called_once_with(JobStatus.FINISHED_WITH_ERROR, mock_request.app.database)
+    mock_job.set_error_message(f"Training job terminated manually on {datetime.now()}", mock_request.app.database)
+    mock_requests.get.assert_has_calls([
+        call(url=f"http://{test_clients[0].service_address}/api/client/kill/{test_clients[0].pid}"),
+        call(url=f"http://{test_clients[1].service_address}/api/client/kill/{test_clients[1].pid}"),
+    ])
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 200
+    assert json.loads(response.body.decode("utf-8")) == {"status": "success"}
+
+# TODO test failure cases

--- a/florist/tests/unit/api/test_client.py
+++ b/florist/tests/unit/api/test_client.py
@@ -24,12 +24,17 @@ def test_start_success(mock_launch_client: Mock) -> None:
     test_data_path = "test/data/path"
     test_redis_host = "test-redis-host"
     test_redis_port = "test-redis-port"
+    test_client_pid = 1234
+
+    mock_client_process = Mock()
+    mock_client_process.pid = test_client_pid
+    mock_launch_client.return_value = mock_client_process
 
     response = client.start(test_server_address, test_client, test_data_path, test_redis_host, test_redis_port)
 
     assert response.status_code == 200
     json_body = json.loads(response.body.decode())
-    assert json_body == {"uuid": ANY}
+    assert json_body == {"uuid": ANY, "pid": str(test_client_pid)}
 
     log_file_name = str(get_client_log_file_path(json_body["uuid"]))
     mock_launch_client.assert_called_once_with(ANY, test_server_address, log_file_name)

--- a/florist/tests/unit/api/test_client.py
+++ b/florist/tests/unit/api/test_client.py
@@ -127,27 +127,27 @@ def test_check_status_fail_exception(mock_redis: Mock) -> None:
     assert json.loads(response.body.decode()) == {"error": "test exception"}
 
 @patch("florist.api.client.os.kill")
-def test_kill_success(mock_kill: Mock) -> None:
+def test_stop_success(mock_kill: Mock) -> None:
     test_pid = 1234
 
-    response = client.kill(str(test_pid))
+    response = client.stop(str(test_pid))
 
     assert response.status_code == 200
     assert json.loads(response.body.decode()) == {"status": "success"}
     mock_kill.assert_called_once_with(test_pid, signal.SIGTERM)
 
 
-def test_kill_fail_no_pid() -> None:
-    response = client.kill("")
+def test_stop_fail_no_pid() -> None:
+    response = client.stop("")
 
     assert response.status_code == 400
     assert json.loads(response.body.decode()) == {"error": "PID is not valid: "}
 
 
-def test_kill_fail_exception() -> None:
+def test_stop_fail_exception() -> None:
     test_pid = "inexistant-pid"
 
-    response = client.kill(test_pid)
+    response = client.stop(test_pid)
 
     assert response.status_code == 500
     assert json.loads(response.body.decode()) == {"error": f"invalid literal for int() with base 10: '{test_pid}'"}

--- a/florist/tests/unit/api/test_client.py
+++ b/florist/tests/unit/api/test_client.py
@@ -1,5 +1,6 @@
 """Tests for FLorist's client FastAPI endpoints."""
 import json
+import signal
 from unittest.mock import ANY, Mock, patch
 
 from florist.api import client
@@ -124,3 +125,29 @@ def test_check_status_fail_exception(mock_redis: Mock) -> None:
 
     assert response.status_code == 500
     assert json.loads(response.body.decode()) == {"error": "test exception"}
+
+@patch("florist.api.client.os.kill")
+def test_kill_success(mock_kill: Mock) -> None:
+    test_pid = 1234
+
+    response = client.kill(str(test_pid))
+
+    assert response.status_code == 200
+    assert json.loads(response.body.decode()) == {"status": "success"}
+    mock_kill.assert_called_once_with(test_pid, signal.SIGTERM)
+
+
+def test_kill_fail_no_pid() -> None:
+    response = client.kill("")
+
+    assert response.status_code == 400
+    assert json.loads(response.body.decode()) == {"error": "PID is not valid: "}
+
+
+def test_kill_fail_exception() -> None:
+    test_pid = "inexistant-pid"
+
+    response = client.kill(test_pid)
+
+    assert response.status_code == 500
+    assert json.loads(response.body.decode()) == {"error": f"invalid literal for int() with base 10: '{test_pid}'"}

--- a/florist/tests/unit/api/test_client.py
+++ b/florist/tests/unit/api/test_client.py
@@ -160,7 +160,7 @@ def test_stop_fail_no_pid() -> None:
     response = client.stop("")
 
     assert response.status_code == 400
-    assert json.loads(response.body.decode()) == {"error": "PID is not valid: "}
+    assert json.loads(response.body.decode()) == {"error": "PID is empty or None."}
 
 
 def test_stop_fail_exception() -> None:

--- a/florist/tests/unit/app/jobs/details/page.test.tsx
+++ b/florist/tests/unit/app/jobs/details/page.test.tsx
@@ -41,6 +41,7 @@ function makeTestJob(): JobData {
         server_address: "test-server-address",
         redis_host: "test-redis-host",
         redis_port: "test-redis-port",
+        error_message: "test-error-message",
         server_config: JSON.stringify({
             test_attribute_1: "test-value-1",
             test_attribute_2: "test-value-2",
@@ -244,6 +245,25 @@ describe("Job Details Page", () => {
             expect(statusComponent).toHaveClass("alert-secondary");
             const iconComponent = statusComponent.querySelector("#job-details-status-icon");
             expect(iconComponent).toHaveTextContent("");
+        });
+    });
+    describe("Error Message", () => {
+        it("Should render when error message is present", () => {
+            const testJob = makeTestJob();
+            setupGetJobMock(testJob);
+            const { container } = render(<JobDetails />);
+
+            const errorMessageComponent = container.querySelector("#job-details-error-message");
+            expect(errorMessageComponent).toHaveTextContent(testJob.error_message);
+        });
+        it("Should render when error message is present", () => {
+            const testJob = makeTestJob();
+            testJob.error_message = null;
+            setupGetJobMock(testJob);
+            const { container } = render(<JobDetails />);
+
+            const errorMessageComponent = container.querySelector("#job-details-error-message");
+            expect(errorMessageComponent).toBeNull();
         });
     });
     describe("Job progress", () => {

--- a/florist/tests/unit/app/jobs/details/page.test.tsx
+++ b/florist/tests/unit/app/jobs/details/page.test.tsx
@@ -345,6 +345,7 @@ describe("Job Details Page", () => {
             });
             it("Should render the contents correctly", () => {
                 const testJob = makeTestJob();
+                testJob.status = "IN_PROGRESS";
                 const serverMetrics = JSON.parse(testJob.server_metrics);
                 setupGetJobMock(testJob);
                 setupURLSpyMock(urlSpy);
@@ -553,6 +554,7 @@ describe("Job Details Page", () => {
             describe("Clients", () => {
                 it("Renders their progress bars correctly", () => {
                     const testJob = makeTestJob();
+                    testJob.status = "IN_PROGRESS";
                     setupGetJobMock(testJob);
                     const { container } = render(<JobDetails />);
                     const clientsProgress = container.querySelectorAll(".job-client-progress");
@@ -567,6 +569,7 @@ describe("Job Details Page", () => {
                 });
                 it("Renders the progress details correctly", () => {
                     const testJob = makeTestJob();
+                    testJob.status = "IN_PROGRESS";
                     setupGetJobMock(testJob);
                     setupURLSpyMock(urlSpy);
                     const { container } = render(<JobDetails />);

--- a/florist/tests/unit/app/jobs/page.test.tsx
+++ b/florist/tests/unit/app/jobs/page.test.tsx
@@ -175,7 +175,7 @@ describe("List Jobs Page", () => {
 
         for (let status of validStatusesKeys) {
             const element = queryByTestId(`job-details-button-${status}-0`);
-            expect(element.getAttribute("alt")).toBe("Details");
+            expect(element.getAttribute("title")).toBe("Details");
             expect(element.getAttribute("href")).toBe(`jobs/details?id=${data._id}`);
         }
     });

--- a/florist/tests/unit/app/jobs/page.test.tsx
+++ b/florist/tests/unit/app/jobs/page.test.tsx
@@ -58,9 +58,15 @@ function mockUsePost(postMock, isLoading) {
     };
 }
 
-function setupMock(validStatuses: Array<string>, data: Array<object>, error: boolean, isLoading: boolean, isPostLoading: boolean) {
+function setupMock(
+    validStatuses: Array<string>,
+    data: Array<object>,
+    error: boolean,
+    isLoading: boolean,
+    isPostLoading: boolean,
+) {
     useGetJobsByJobStatus.mockImplementation((status: string) =>
-        mockUseGetJobsByJobStatus(status, validStatuses, data, error, isLoading)
+        mockUseGetJobsByJobStatus(status, validStatuses, data, error, isLoading),
     );
     const postMock = jest.fn();
     usePost.mockImplementation(() => mockUsePost(postMock, isPostLoading));
@@ -123,14 +129,26 @@ describe("List Jobs Page", () => {
     });
 
     it("Renders Loading GIF only when all isLoading", () => {
-        setupMock(["NOT_STARTED", "IN_PROGRESS", "FINISHED_SUCCESSFULLY", "FINISHED_WITH_ERROR"], [], false, true, false);
+        setupMock(
+            ["NOT_STARTED", "IN_PROGRESS", "FINISHED_SUCCESSFULLY", "FINISHED_WITH_ERROR"],
+            [],
+            false,
+            true,
+            false,
+        );
         const { getByTestId } = render(<Page />);
         const element = getByTestId("jobs-page-loading-gif");
         expect(element).toBeInTheDocument();
     });
 
     it("Doesn't Render Loading GIF when not Loading", () => {
-        setupMock(["NOT_STARTED", "IN_PROGRESS", "FINISHED_SUCCESSFULLY", "FINISHED_WITH_ERROR"], [], false, false, false);
+        setupMock(
+            ["NOT_STARTED", "IN_PROGRESS", "FINISHED_SUCCESSFULLY", "FINISHED_WITH_ERROR"],
+            [],
+            false,
+            false,
+            false,
+        );
         const { queryByTestId } = render(<Page />);
         const element = queryByTestId("jobs-page-loading-gif");
         expect(element).not.toBeInTheDocument();

--- a/florist/tests/unit/app/jobs/page.test.tsx
+++ b/florist/tests/unit/app/jobs/page.test.tsx
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom";
 import { getByText, render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
 import { describe, it, expect, afterEach } from "@jest/globals";
+import { act } from "react-dom/test-utils";
 
 import Page from "../../../../app/jobs/page";
 import { validStatuses } from "../../../../app/jobs/definitions";
@@ -48,58 +49,27 @@ function mockUseGetJobsByJobStatus(
     }
 }
 
-function mockUsePost() {
+function mockUsePost(postMock, isLoading) {
     return {
-        post: jest.fn(),
+        post: postMock,
         response: null,
-        isLoading: false,
+        isLoading: isLoading,
         error: null,
     };
 }
 
-function setupMock(validStatuses: Array<string>, data: Array<object>, error: boolean, isLoading: boolean) {
+function setupMock(validStatuses: Array<string>, data: Array<object>, error: boolean, isLoading: boolean, isPostLoading: boolean) {
     useGetJobsByJobStatus.mockImplementation((status: string) =>
-        mockUseGetJobsByJobStatus(status, validStatuses, data, error, isLoading),
+        mockUseGetJobsByJobStatus(status, validStatuses, data, error, isLoading)
     );
-    usePost.mockImplementation(() => mockUsePost());
-}
-
-// Function that mocks useGetJobsByJobStatus with different values on successive calls
-// In particular, return data in the initial call and than no data in the subsequent call
-// Grouped in fours because function is called once per status and 4 statuses exist
-function setupChangingMock(validStatuses: Array<string>, data: Array<object>, error: boolean, isLoading: boolean) {
-    useGetJobsByJobStatus
-        .mockImplementationOnce((status: string) =>
-            mockUseGetJobsByJobStatus(status, validStatuses, data, error, isLoading),
-        )
-        .mockImplementationOnce((status: string) =>
-            mockUseGetJobsByJobStatus(status, validStatuses, data, error, isLoading),
-        )
-        .mockImplementationOnce((status: string) =>
-            mockUseGetJobsByJobStatus(status, validStatuses, data, error, isLoading),
-        )
-        .mockImplementationOnce((status: string) =>
-            mockUseGetJobsByJobStatus(status, validStatuses, data, error, isLoading),
-        )
-        .mockImplementationOnce((status: string) =>
-            mockUseGetJobsByJobStatus(status, validStatuses, [], error, isLoading),
-        )
-        .mockImplementationOnce((status: string) =>
-            mockUseGetJobsByJobStatus(status, validStatuses, [], error, isLoading),
-        )
-        .mockImplementationOnce((status: string) =>
-            mockUseGetJobsByJobStatus(status, validStatuses, [], error, isLoading),
-        )
-        .mockImplementationOnce((status: string) =>
-            mockUseGetJobsByJobStatus(status, validStatuses, [], error, isLoading),
-        );
-
-    usePost.mockImplementation(() => mockUsePost());
+    const postMock = jest.fn();
+    usePost.mockImplementation(() => mockUsePost(postMock, isPostLoading));
+    return postMock;
 }
 
 describe("List Jobs Page", () => {
     it("Renders Page Header Correctly", () => {
-        setupMock([], [], false, false);
+        setupMock([], [], false, false, false);
         const { container } = render(<Page />);
         const h1 = container.querySelector("h1");
         expect(h1).toBeInTheDocument();
@@ -113,7 +83,7 @@ describe("List Jobs Page", () => {
         const data = [mockJobData("MNIST", "localhost:8080", ["localhost:7080"])];
         const validStatusesKeys = Object.keys(validStatuses);
 
-        setupMock(validStatusesKeys, data, false, false);
+        setupMock(validStatusesKeys, data, false, false, false);
         const { getByTestId } = render(<Page />);
 
         for (const status of validStatusesKeys) {
@@ -127,7 +97,7 @@ describe("List Jobs Page", () => {
         const data = [mockJobData("MNIST", "localhost:8080", ["localhost:7080"])];
         const validStatusesKeys = Object.keys(validStatuses);
 
-        setupMock(validStatusesKeys, data, false, false);
+        setupMock(validStatusesKeys, data, false, false, false);
 
         const { getByTestId } = render(<Page />);
 
@@ -143,7 +113,7 @@ describe("List Jobs Page", () => {
     });
 
     it("Renders Status Table without Data", () => {
-        setupMock([], [], false, false);
+        setupMock([], [], false, false, false);
         const { getByTestId } = render(<Page />);
 
         for (const status of Object.keys(validStatuses)) {
@@ -153,14 +123,14 @@ describe("List Jobs Page", () => {
     });
 
     it("Renders Loading GIF only when all isLoading", () => {
-        setupMock(["NOT_STARTED", "IN_PROGRESS", "FINISHED_SUCCESSFULLY", "FINISHED_WITH_ERROR"], [], false, true);
+        setupMock(["NOT_STARTED", "IN_PROGRESS", "FINISHED_SUCCESSFULLY", "FINISHED_WITH_ERROR"], [], false, true, false);
         const { getByTestId } = render(<Page />);
         const element = getByTestId("jobs-page-loading-gif");
         expect(element).toBeInTheDocument();
     });
 
     it("Doesn't Render Loading GIF when not Loading", () => {
-        setupMock(["NOT_STARTED", "IN_PROGRESS", "FINISHED_SUCCESSFULLY", "FINISHED_WITH_ERROR"], [], false, false);
+        setupMock(["NOT_STARTED", "IN_PROGRESS", "FINISHED_SUCCESSFULLY", "FINISHED_WITH_ERROR"], [], false, false, false);
         const { queryByTestId } = render(<Page />);
         const element = queryByTestId("jobs-page-loading-gif");
         expect(element).not.toBeInTheDocument();
@@ -170,7 +140,7 @@ describe("List Jobs Page", () => {
         const data = mockJobData("MNIST", "localhost:8080", ["localhost:7080"]);
         const validStatusesKeys = Object.keys(validStatuses);
 
-        setupMock(validStatusesKeys, [data], false, false);
+        setupMock(validStatusesKeys, [data], false, false, false);
         const { queryByTestId } = render(<Page />);
 
         for (let status of validStatusesKeys) {
@@ -180,43 +150,112 @@ describe("List Jobs Page", () => {
         }
     });
 
-    it("Start training button present in NOT_STARTED jobs", () => {
-        const data = [mockJobData("MNIST", "localhost:8080", ["localhost:7080"])];
-        const validStatusesKeys = Object.keys(validStatuses);
+    describe("Start training button", () => {
+        it("Is present in NOT_STARTED jobs", () => {
+            const data = [mockJobData("MNIST", "localhost:8080", ["localhost:7080"])];
+            const validStatusesKeys = Object.keys(validStatuses);
+            const statuses = ["NOT_STARTED"];
 
-        setupMock(validStatusesKeys, data, false, false);
-        const { queryByTestId } = render(<Page />);
-        const element = queryByTestId("start-training-button-0");
-        expect(element).toBeInTheDocument();
-    });
+            setupMock(statuses, data, false, false, false);
+            const { queryByTestId } = render(<Page />);
+            const startTrainingButton = queryByTestId("start-training-button-0");
+            const startTrainingIcon = startTrainingButton.querySelector("i");
 
-    it("Start training button not present without NOT_STARTED jobs", () => {
-        const data = [mockJobData("MNIST", "localhost:8080", ["localhost:7080"])];
-        const statuses = ["IN_PROGRESS"];
-
-        setupMock(statuses, data, false, false);
-        const { queryByTestId } = render(<Page />);
-        const element = queryByTestId("start-training-button-0");
-        expect(element).not.toBeInTheDocument();
-    });
-
-    it("Start training button not present after started", () => {
-        const data = [mockJobData("MNIST", "localhost:8080", ["localhost:7080"])];
-        const statuses = ["NOT_STARTED"];
-
-        setupChangingMock(statuses, data, false, false);
-        render(<Page />);
-        const element = screen.queryByTestId("start-training-button-0");
-        expect(element).toBeInTheDocument();
-
-        const button = screen.getByRole("button", {
-            name: (_, element) => element.title === "Start",
+            expect(startTrainingButton).toBeInTheDocument();
+            expect(startTrainingButton).toHaveClass("btn-primary");
+            expect(startTrainingIcon).toHaveClass("material-icons");
+            expect(startTrainingIcon).toHaveTextContent("play_circle_outline");
         });
-        fireEvent.click(button);
 
-        waitFor(() => {
-            const new_element = screen.queryByTestId("start-training-button-0");
-            expect(new_element).not.toBeInTheDocument();
+        it("Is not present without NOT_STARTED jobs", () => {
+            const data = [mockJobData("MNIST", "localhost:8080", ["localhost:7080"])];
+            const statuses = ["IN_PROGRESS", "FINISHED_WITH_ERROR", "FINISHED_SUCCESSFULLY"];
+
+            setupMock(statuses, data, false, false, false);
+            const { queryByTestId } = render(<Page />);
+            const startTrainingButton = queryByTestId("start-training-button-0");
+            expect(startTrainingButton).not.toBeInTheDocument();
+        });
+
+        it("Clicking it will call the backend API", () => {
+            const data = [mockJobData("MNIST", "localhost:8080", ["localhost:7080"])];
+            const statuses = ["NOT_STARTED"];
+
+            const postMock = setupMock(statuses, data, false, false, false);
+            const { queryByTestId } = render(<Page />);
+            const startTrainingButton = queryByTestId("start-training-button-0");
+
+            act(() => startTrainingButton.click());
+
+            expect(postMock).toHaveBeenCalledWith("/api/server/training/start?job_id=test-id", "{}");
+        });
+
+        it("Should be disabled and display a spinner when loading", () => {
+            const data = [mockJobData("MNIST", "localhost:8080", ["localhost:7080"])];
+            const statuses = ["NOT_STARTED"];
+
+            const postMock = setupMock(statuses, data, false, false, true);
+            const { queryByTestId } = render(<Page />);
+            const startTrainingButton = queryByTestId("start-training-button-0");
+            const startTrainingSpinner = startTrainingButton.querySelector("span");
+
+            expect(startTrainingButton).not.toHaveClass("btn-primary");
+            expect(startTrainingButton).toHaveClass("btn-secondary", "disabled");
+            expect(startTrainingSpinner).toHaveClass("spinner-border");
+        });
+    });
+
+    describe("Stop training button", () => {
+        it("Is present in IN_PROGRESS jobs", () => {
+            const data = [mockJobData("MNIST", "localhost:8080", ["localhost:7080"])];
+            const statuses = ["IN_PROGRESS"];
+
+            setupMock(statuses, data, false, false, false);
+            const { queryByTestId } = render(<Page />);
+            const stopTrainingButton = queryByTestId("stop-training-button-0");
+            const stopTrainingIcon = stopTrainingButton.querySelector("i");
+
+            expect(stopTrainingButton).toBeInTheDocument();
+            expect(stopTrainingButton).toHaveClass("btn-primary");
+            expect(stopTrainingIcon).toHaveClass("material-icons");
+            expect(stopTrainingIcon).toHaveTextContent("stop");
+        });
+
+        it("Is not present without IN_PROGRESS jobs", () => {
+            const data = [mockJobData("MNIST", "localhost:8080", ["localhost:7080"])];
+            const statuses = ["NOT_STARTED", "FINISHED_WITH_ERROR", "FINISHED_SUCCESSFULLY"];
+
+            setupMock(statuses, data, false, false, false);
+            const { queryByTestId } = render(<Page />);
+            const stopTrainingButton = queryByTestId("stop-training-button-0");
+            expect(stopTrainingButton).not.toBeInTheDocument();
+        });
+
+        it("Clicking it will call the backend API", () => {
+            const data = [mockJobData("MNIST", "localhost:8080", ["localhost:7080"])];
+            const statuses = ["IN_PROGRESS"];
+
+            const postMock = setupMock(statuses, data, false, false, false);
+            const { queryByTestId } = render(<Page />);
+            const stopTrainingButton = queryByTestId("stop-training-button-0");
+
+            act(() => stopTrainingButton.click());
+
+            expect(postMock).toHaveBeenCalledWith("/api/server/job/stop/test-id", "{}");
+        });
+
+        it("Should be disabled and display a spinner when loading", () => {
+            const data = [mockJobData("MNIST", "localhost:8080", ["localhost:7080"])];
+            const statuses = ["IN_PROGRESS"];
+
+            const postMock = setupMock(statuses, data, false, false, true);
+            const { queryByTestId } = render(<Page />);
+            const stopTrainingButton = queryByTestId("stop-training-button-0");
+            const stopTrainingSpinner = stopTrainingButton.querySelector("span");
+
+            expect(stopTrainingButton).not.toHaveClass("btn-primary");
+            expect(stopTrainingButton).toHaveClass("btn-secondary", "disabled");
+            expect(stopTrainingSpinner).toHaveClass("spinner-border");
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1439,9 +1439,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001449, caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001587:
-  version "1.0.30001617"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001617.tgz#809bc25f3f5027ceb33142a7d6c40759d7a901eb"
-  integrity sha512-mLyjzNI9I+Pix8zwcrpxEbGlfqOkF9kM3ptzmKNw5tizSyYwMe+nGLTqMK9cO+0E+Bh6TsBxNAaHWEM8xwSsmA==
+  version "1.0.30001690"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz"
+  integrity sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==
 
 chalk@^2.4.2:
   version "2.4.2"


### PR DESCRIPTION
# PR Type
Feature

# Short Description

Clickup Ticket(s): [Link(s) if applicable.](https://app.clickup.com/t/868b1x7d6)

Adding a button on in-progress jobs to stop it. Clicking on it will call an API that will ultimately kill the clients' processes and the server processes.

In this PR I am:
- Saving the client and server PIDs in the database so they can be retrieved later
- Adding an API on the client that will allow to kill a client given its PID
- Adding an API on the server to stop a job. This API will call the client APIs one by one, and then it will kill the server process. It will also change the job status to "Finished With Error" and write down an error message.
- As a bonus, now that we have an error message field, I'm also setting it to the exception message when the `/start` endpoint fails
- Adding the stop button only for jobs that are in progress

![Screenshot 2025-01-07 at 14 12 33](https://github.com/user-attachments/assets/b07b25f7-946e-4c41-a89a-b7c5716c62a1)

# Tests Added
Fully unit and integration tested
