### PR TITLE
Adding job UUID to the list jobs page

### DIFF
--- a/florist/app/jobs/page.tsx
+++ b/florist/app/jobs/page.tsx
@@ -166,6 +166,9 @@ export function StatusTable({ data, status }: { data: Array<JobData>; status: St
                         <thead>
                             <tr>
                                 <th className="text-uppercase text-secondary text-xxs font-weight-bolder opacity-7">
+                                    UUID
+                                </th>
+                                <th className="text-uppercase text-secondary text-xxs font-weight-bolder opacity-7">
                                     Model
                                 </th>
                                 <th className="text-uppercase text-secondary text-xxs font-weight-bolder opacity-7">
@@ -231,6 +234,11 @@ export function TableRow({
 
     return (
         <tr>
+            <td>
+                <div className="d-flex flex-column justify-content-center">
+                    <span className="ps-3 text-secondary text-xs font-weight-bold">{jobId}</span>
+                </div>
+            </td>
             <td>
                 <div className="d-flex flex-column justify-content-center">
                     <span className="ps-3 text-secondary text-xs font-weight-bold">{model}</span>

--- a/florist/tests/unit/app/jobs/page.test.tsx
+++ b/florist/tests/unit/app/jobs/page.test.tsx
@@ -133,6 +133,7 @@ describe("List Jobs Page", () => {
 
         for (const status of validStatusesKeys) {
             const element = getByTestId(`status-table-${status}`);
+            expect(getByText(element, "UUID")).toBeInTheDocument();
             expect(getByText(element, "Model")).toBeInTheDocument();
             expect(getByText(element, "Server Address")).toBeInTheDocument();
             expect(getByText(element, "Client Service Addresses")).toBeInTheDocument();


### PR DESCRIPTION
# PR Type
Feature

# Short Description

Clickup Ticket(s): NA

This PR is adding the job UUID to the list jobs page to make it easier to identify which training job is which, especially when there is a long list.
![Screenshot 2025-01-30 at 09 55 22](https://github.com/user-attachments/assets/086a7103-783d-4988-a558-068fd401cd76)

# Tests Added
NA
