### PR TITLE
Fixing pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,8 +28,8 @@ repos:
     rev: v1.15.0
     hooks:
     - id: mypy
-      entry: python3 -m mypy --config-file pyproject.toml
-      language: system
+      entry: ./venv/bin/python -m mypy --config-file pyproject.toml
+      language: python
       types: [python]
       exclude: "florist/tests/"
 
@@ -65,16 +65,16 @@ repos:
     hooks:
     - id: doctest
       name: doctest
-      entry: python3 -m doctest -o NORMALIZE_WHITESPACE
+      entry: ./venv/bin/python -m doctest -o NORMALIZE_WHITESPACE
       files: "(^florist/api/|florist/tests/api/)"
-      language: system
+      language: python
 
   - repo: local
     hooks:
     - id: pytest-unit
       name: pytest-unit
-      entry: python -m pytest florist/tests/unit
-      language: system
+      entry: ./venv/bin/python -m pytest florist/tests/unit
+      language: python
       pass_filenames: false
       always_run: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
     hooks:
     - id: doctest
       name: doctest
-      entry: ./venv/bin/python -m doctest -o NORMALIZE_WHITESPACE
+      entry: python -m doctest -o NORMALIZE_WHITESPACE
       files: "(^florist/api/|florist/tests/api/)"
       language: python
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
     hooks:
     - id: doctest
       name: doctest
-      entry: python -m doctest -o NORMALIZE_WHITESPACE
+      entry: ./venv/bin/python -m doctest -o NORMALIZE_WHITESPACE
       files: "(^florist/api/|florist/tests/api/)"
       language: python
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,23 +5,19 @@ Thanks for your interest in contributing!
 To submit PRs, please fill out the PR template along with the PR. If the PR
 fixes an issue, don't forget to link the PR to the issue!
 
-## Pre-commit hooks
+## Virtual Environment
 
-Once the python virtual environment is setup, you can run pre-commit hooks using:
+To install development dependencies, first you need to create a virtual environment.
+It's important to create it with the name `venv`, and you can do so with the commands below.
+If you wish to use a different virtual environment name, you should also update the
+[`.pre-commit-config.yaml`](./.pre-commit-config.yaml) file.
 
-```bash
-pre-commit run --all-files
+```shell
+python -m venv venv
+source venv/bin/activate
 ```
 
 ## Development dependencies
-
-To install development dependencies, first you need to create a virtual environment.
-The easiest way is by using the [virtualenv](https://pypi.org/project/virtualenv/) package:
-
-```shell
-virtualenv venv
-source venv/bin/activate
-```
 
 We use [Poetry](https://python-poetry.org/) to manage back-end dependencies:
 
@@ -52,6 +48,27 @@ To start the server in development mode, run:
 ```shell
 yarn dev
 ```
+
+## Pre-commit hooks
+
+Once the python virtual environment is setup, you can run pre-commit hooks.
+First, you should install the `pre-commit` tool using pip:
+
+```bash
+pip install pre-commit
+```
+
+Then, you should install the project's pre-commit hooks into your environment:
+```bash
+pre-commit install
+```
+
+Now you can run the pre-commit hooks in the project:
+```bash
+pre-commit run --all-files
+```
+
+It will also automatically run whenever you commit a file into the git repository.
 
 ## Running the tests
 


### PR DESCRIPTION
# PR Type
Fix

# Short Description

Clickup Ticket(s): NA

While solving issues using Cursor's UI to commit and push into git, I came up with the solution in this PR for pre-commit hooks. The downside is that now the name of the virtual environment is hardcoded to `venv`. Let me know if you have better solutions.

# Tests Added
NA
