### PR TITLE
Removing the log line that tells the metrics are not being dumped so we don't spam the logs

### DIFF
--- a/florist/api/monitoring/metrics.py
+++ b/florist/api/monitoring/metrics.py
@@ -123,9 +123,9 @@ class RedisMetricsReporter(BaseReporter):  # type: ignore
             previous_metrics = json.loads(previous_metrics_blob)
             current_metrics = json.loads(encoded_metrics)
             if current_metrics == previous_metrics:
-                log(
-                    DEBUG, f"Skipping dumping: previous metrics are the same as current metrics at key '{self.run_id}'"
-                )
+                # Skipping dumping here because previous metrics are the same as current metrics.
+                # This is necessary in this class because we are calling dump within the report method,
+                # which is called for every input of the model. Also not logging here to avoid spamming the logs.
                 return
 
         log(DEBUG, f"Dumping metrics to redis at key '{self.run_id}': {encoded_metrics}")


### PR DESCRIPTION
# PR Type
Fix

# Short Description

Clickup Ticket(s): NA

The client logs were being littered with the message saying the metrics will not be dumped because they haven't changed. Upon investigation, I noticed the reporters are called for every input of the model, which may make sense for some reporters but not this one. So I removed the log message in order to stop the logs from being spammed as everything else is working as expected.

# Tests Added
NA
